### PR TITLE
PR Fixing Pattern Variables being dropped, see #844

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,4 +1,8 @@
 * Changelog for Juvix
+** 0.1.1.5
+- Fix: Bug in #809 and #844, where pattern variables were considered
+  to be global variables.
+  + Add: Tests for the bug
 ** 0.1.1.4
 - Adds: easy pipeline support up to Core.
   + Creates: A time-lapse function

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1814,7 +1814,9 @@ _TODO_
 ******* Def
 - _Relies on_
   + [[Juvix/Context]]
+  + [[Core/HR]]
   + [[Core/IR]]
+  + [[Translate]]
   + [[Translate]]
   + [[Library]]
   + [[NameSymbol]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -63,7 +63,7 @@ Module that implements the backend parameters for the Michelson backend.
   + [[Library]]
   + [[Feedback]]
   + [[Juvix/Pipeline]]
-  + [[FromFrontend]]
+  + [[ToCore/FromFrontend]]
 ******* Compilation <<Michelson/Compilation>>
 - Entrypoints into compilation from core terms to Michelson terms & contracts.
 - _Relies on_
@@ -281,7 +281,7 @@ Surface language
   + [[Library]]
   + [[Feedback]]
   + [[Juvix/Pipeline]]
-  + [[FromFrontend]]
+  + [[ToCore/FromFrontend]]
 ******* Types <<Plonk/Types>>
 - _Relies on_
   + [[Application]]
@@ -375,7 +375,7 @@ The basic connection between the backend and the Juvix pipeline.
   + [[Library]]
   + [[Feedback]]
   + [[Juvix/Pipeline]]
-  + [[FromFrontend]]
+  + [[ToCore/FromFrontend]]
 ******* Primitive
 Representation of LLVM primitives in Juvix.
 - _Relies on_
@@ -986,7 +986,14 @@ with any stage of the compiler while modifying the source code.
   + [[Compile]]
   + [[ToCore/Types]]
 ** test
+*** FromFrontend <<test/FromFrontend>>
+- _Relies on_
+  + [[IR/Types]]
+  + [[Library]]
+  + [[ToCore/Types]]
 *** Spec <<EasyPipeline/test/Spec>>
+- _Relies on_
+  + [[Library]]
 * Frontend
 ** Setup <<Frontend/Setup>>
 ** src
@@ -1430,7 +1437,7 @@ Can be added to via core translation
   + [[Library/Parser]]
   + [[Library/Sexp]]
   + [[Library/Usage]]
-  + [[FromFrontend]]
+  + [[ToCore/FromFrontend]]
 ***** Types <<Pipeline/Types>>
 - _Relies on_
   + [[ErasedAnn/Types]]
@@ -1803,7 +1810,7 @@ _TODO_
   + [[NameSymbol]]
   + [[Library/Sexp]]
   + [[Library/Usage]]
-***** FromFrontend
+***** FromFrontend <<ToCore/FromFrontend>>
 - _Relies on_
   + [[Transform]]
   + [[ToCore/Types]]

--- a/library/Core/src/Juvix/Core/Translate.hs
+++ b/library/Core/src/Juvix/Core/Translate.hs
@@ -269,7 +269,8 @@ exec pats avoid (M env) =
       }
 
 -- | @execSymToPat@ works like exec but takes the symtoPat map instead of the patToSym map
-execSymToPat :: HashMap NameSymbol.T IR.PatternVar -> HashSet NameSymbol.T -> M a -> (a, Env)
+execSymToPat ::
+  HashMap NameSymbol.T IR.PatternVar -> HashSet NameSymbol.T -> M a -> (a, Env)
 execSymToPat pats = exec (HM.toList pats |> map swap |> PM.fromList)
 
 -- TODO separate states for h→i and i→h maybe??

--- a/library/Core/test/Conv.hs
+++ b/library/Core/test/Conv.hs
@@ -11,6 +11,14 @@ shouldConvertHR :: HR.Term () () -> IR.Term () () -> T.TestTree
 shouldConvertHR hr ir =
   T.testCase (show hr <> " should convert to " <> show ir) (ir T.@=? Trans.hrToIR hr)
 
+shouldConvertHRWith ::
+  Traversable t => t (HR.Pattern () ()) -> HR.Term () () -> IR.Term () () -> T.TestTree
+shouldConvertHRWith pats hr ir =
+  T.testCase (show hr <> " should convert to " <> show ir) (ir T.@=? convertWith pats hr)
+
+convertWith :: Traversable t => t (HR.Pattern () ()) -> HR.Term () () -> IR.Term () ()
+convertWith pats = Trans.hrToIRWith (snd (Trans.hrPatternsToIR pats))
+
 shouldConvertIR :: IR.Term () () -> HR.Term () () -> T.TestTree
 shouldConvertIR ir hr =
   T.testCase (show ir <> " should convert to " <> show hr) (hr T.@=? Trans.irToHR ir)
@@ -48,7 +56,11 @@ hrToirConversion =
               IR.Bound 0
                 `IR.App` IR.Lam (IR.Elim $ IR.Bound 0)
                 `IR.App` IR.Lam (IR.Elim $ IR.Free (IR.Global "x"))
-        )
+        ),
+      shouldConvertHRWith
+        [HR.PVar "a", HR.PVar "hi"]
+        (HR.Elim (HR.Var "a"))
+        (IR.Elim (IR.Free (IR.Pattern 0)))
     ]
 
 irTohrConversion :: T.TestTree

--- a/library/EasyPipeline/package.yaml
+++ b/library/EasyPipeline/package.yaml
@@ -121,3 +121,8 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - EasyPipeline
+    - tasty
+    - tasty-golden
+    - tasty-hunit
+    - tasty-silver
+    - tasty-quickcheck

--- a/library/EasyPipeline/src/Easy.hs
+++ b/library/EasyPipeline/src/Easy.hs
@@ -388,6 +388,16 @@ printModule name ctx =
     Nothing ->
       pure ()
 
+lookupCoreFunction ::
+  ToCore.Types.CoreDefs primTy1 primVal1 ->
+  Options primTy2 primVal2 ->
+  Symbol ->
+  Maybe (ToCore.Types.CoreDef primTy1 primVal1)
+lookupCoreFunction core option functionName =
+  let name =
+        currentContextName option <> NameSymb.fromSymbol functionName
+   in Map.lookup name (ToCore.Types.defs core)
+
 printCoreFunction ::
   (MonadIO m, Show primTy1, Show primVal1) =>
   ToCore.Types.CoreDefs primTy1 primVal1 ->
@@ -395,10 +405,7 @@ printCoreFunction ::
   Symbol ->
   m ()
 printCoreFunction core option functionName =
-  let name =
-        currentContextName option <> NameSymb.fromSymbol functionName
-   in Map.lookup name (ToCore.Types.defs core)
-        |> printCompactParens
+  lookupCoreFunction core option functionName |> printCompactParens
 
 printTimeLapse ::
   (Show primTy2, Show primVal2) => ByteString -> Options primTy2 primVal2 -> IO ()

--- a/library/EasyPipeline/test/FromFrontend.hs
+++ b/library/EasyPipeline/test/FromFrontend.hs
@@ -1,0 +1,48 @@
+module FromFrontend where
+
+import qualified Easy
+import qualified Juvix.Core.IR.Types as IR
+import Juvix.Library
+import qualified Juvix.ToCore.Types as Types
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+
+--------------------------------------------------------------------------------
+-- Top
+--------------------------------------------------------------------------------
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "From Frontend Tests:"
+    [patternVarTests]
+
+--------------------------------------------------------------------------------
+-- tests
+--------------------------------------------------------------------------------
+
+patternVarTests =
+  T.testGroup
+    "pattern Var Tests"
+    [ T.testCase
+        "pattern vars should be tracked"
+        ( do
+            pattern' <- rawPattern
+            pattern' T.@=? rawPatternShouldBe
+        )
+    ]
+  where
+    rawPattern = do
+      Right x <- Easy.coreify "sig foo : int let foo x = x" Easy.defMichelson
+      let Just
+            ( Types.CoreDef
+                ( IR.RawGFunction
+                    IR.RawFunction
+                      { IR.rawFunClauses = IR.RawFunClause {IR.rawClauseBody = body} :| []
+                      }
+                  )
+              ) =
+              Easy.lookupCoreFunction x Easy.defMichelson "foo"
+      pure body
+    rawPatternShouldBe =
+      IR.Elim (IR.Free (IR.Pattern 0))

--- a/library/EasyPipeline/test/FromFrontend.hs
+++ b/library/EasyPipeline/test/FromFrontend.hs
@@ -28,21 +28,49 @@ patternVarTests =
         "pattern vars should be tracked"
         ( do
             pattern' <- rawPattern
-            pattern' T.@=? rawPatternShouldBe
+            rawPatternShouldBe T.@=? pattern'
+        ),
+      T.testCase
+        "Multiple variables should be tracked"
+        ( do
+            pattern' <- rawPatternAdd
+            rawPatternAddShouldBe T.@=? pattern'
         )
     ]
   where
     rawPattern = do
       Right x <- Easy.coreify "sig foo : int let foo x = x" Easy.defMichelson
-      let Just
-            ( Types.CoreDef
-                ( IR.RawGFunction
-                    IR.RawFunction
-                      { IR.rawFunClauses = IR.RawFunClause {IR.rawClauseBody = body} :| []
-                      }
-                  )
-              ) =
-              Easy.lookupCoreFunction x Easy.defMichelson "foo"
-      pure body
+      pure (grabSingleBody (Easy.lookupCoreFunction x Easy.defMichelson "foo"))
     rawPatternShouldBe =
       IR.Elim (IR.Free (IR.Pattern 0))
+    rawPatternAdd = do
+      Right x <-
+        Easy.coreify
+          "open Prelude\
+          \ open Michelson\
+          \ open Alias\
+          \ sig foo : int -> int\
+          \ let foo x y = x + y"
+          Easy.defMichelson
+      pure $ grabSingleBody (Easy.lookupCoreFunction x Easy.defMichelson "foo")
+    rawPatternAddShouldBe =
+      IR.Elim
+        ( IR.App
+            ( IR.App
+                (IR.Free (IR.Global "Prelude.Michelson.Alias.+"))
+                (IR.Elim (IR.Free (IR.Pattern 0)))
+            )
+            (IR.Elim (IR.Free (IR.Pattern 1)))
+        )
+
+grabSingleBody
+  ( Just
+      ( Types.CoreDef
+          ( IR.RawGFunction
+              IR.RawFunction
+                { IR.rawFunClauses = IR.RawFunClause {IR.rawClauseBody = body} :| []
+                }
+            )
+        )
+    ) =
+    body

--- a/library/EasyPipeline/test/FromFrontend.hs
+++ b/library/EasyPipeline/test/FromFrontend.hs
@@ -49,7 +49,7 @@ patternVarTests =
           "open Prelude\
           \ open Michelson\
           \ open Alias\
-          \ sig foo : int -> int\
+          \ sig foo : int -> int -> int\
           \ let foo x y = x + y"
           Easy.defMichelson
       pure $ grabSingleBody (Easy.lookupCoreFunction x Easy.defMichelson "foo")

--- a/library/EasyPipeline/test/Spec.hs
+++ b/library/EasyPipeline/test/Spec.hs
@@ -1,7 +1,7 @@
 import qualified FromFrontend
+import Juvix.Library
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
-import Juvix.Library
 
 main :: IO ()
 main = T.defaultMain FromFrontend.top

--- a/library/EasyPipeline/test/Spec.hs
+++ b/library/EasyPipeline/test/Spec.hs
@@ -1,4 +1,7 @@
-import Prelude
+import qualified FromFrontend
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import Juvix.Library
 
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main = T.defaultMain FromFrontend.top

--- a/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
+++ b/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
@@ -100,6 +100,7 @@ transformDef x def = do
       | Just args <- Sexp.toList args' = do
         put @"patVars" mempty
         put @"nextPatVar" 0
+        -- TODO :: put this in hrToIRWith
         patts <- traverse transformArg args
         clauseBody <- transformTermIR q body
         pure $ IR.RawFunClause [] patts clauseBody False
@@ -113,6 +114,7 @@ transformDef x def = do
         throwFF $ PatternUnimplemented p
     transformArg pat = transformPat pat
 
+    -- TODO ∷ refactor heavily, we have code in Core that does this
     transformPat p@(asCon Sexp.:> con)
       -- implicit arguments are not supported
       -- TODO ∷ translate as patterns into @let@
@@ -130,5 +132,6 @@ transformDef x def = do
         IR.PPrim <$> getParamConstant n
       | otherwise = error "malformed match pattern"
 
+    -- TODO ∷ remove this, we do this work in Core
     getNextPatVar :: HasNextPatVar m => m IR.PatternVar
     getNextPatVar = state @"nextPatVar" \v -> (v, succ v)

--- a/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
+++ b/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
@@ -104,7 +104,6 @@ transformDef x def = do
       | Just args <- Sexp.toList args' = do
         put @"patVars" mempty
         put @"nextPatVar" 0
-        -- TODO :: put this in hrToIRWith
         pattsHR <- traverse transformArgHR args
         let (patts, pattsTable) = Translate.hrPatternsToIR pattsHR
             transformTermIR q fe =

--- a/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
+++ b/library/Translate/src/Juvix/ToCore/FromFrontend/Transform/Def.hs
@@ -3,8 +3,10 @@ module Juvix.ToCore.FromFrontend.Transform.Def (transformDef) where
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Juvix.Context as Ctx
+import qualified Juvix.Core.HR as HR
 import qualified Juvix.Core.IR as IR
 import Juvix.Core.Translate (hrToIR)
+import qualified Juvix.Core.Translate as Translate
 import Juvix.Library
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Sexp as Sexp
@@ -24,7 +26,9 @@ import Juvix.ToCore.Types
     CoreSig (..),
     Error (..),
     HasNextPatVar,
+    HasParam,
     HasPatVars,
+    HasThrowFF,
     throwFF,
   )
 import Prelude (error)
@@ -101,37 +105,35 @@ transformDef x def = do
         put @"patVars" mempty
         put @"nextPatVar" 0
         -- TODO :: put this in hrToIRWith
-        patts <- traverse transformArg args
+        pattsHR <- traverse transformArgHR args
+        let (patts, pattsTable) = Translate.hrPatternsToIR pattsHR
+            transformTermIR q fe =
+              Translate.hrToIRWith pattsTable <$> transformTermHR q fe
         clauseBody <- transformTermIR q body
         pure $ IR.RawFunClause [] patts clauseBody False
-      where
-        transformTermIR q fe = do
-          hrToIR <$> transformTermHR q fe
     transformClause _ _ = error "malformed tansformClause"
 
-    transformArg p@(name Sexp.:> _rest)
+    transformArgHR p@(name Sexp.:> _rest)
       | Sexp.isAtomNamed name ":implicit-a" =
         throwFF $ PatternUnimplemented p
-    transformArg pat = transformPat pat
+    transformArgHR pat = transformPatHR pat
 
-    -- TODO ∷ refactor heavily, we have code in Core that does this
-    transformPat p@(asCon Sexp.:> con)
+    transformPatHR ::
+      (HasThrowFF primTy primVal m, HasParam primTy primVal m) =>
+      Sexp.T ->
+      m (HR.Pattern primTy primVal)
+    transformPatHR p@(asCon Sexp.:> con)
       -- implicit arguments are not supported
       -- TODO ∷ translate as patterns into @let@
       | Sexp.isAtomNamed asCon ":as" =
         throwFF $ PatternUnimplemented p
       | Just args <- Sexp.toList con,
         Just Sexp.A {atomName} <- Sexp.atomFromT asCon =
-        IR.PCon atomName <$> traverse transformPat args
-    transformPat n
-      | Just x <- eleToSymbol n = do
-        var <- getNextPatVar
-        modify @"patVars" $ HM.insert (NameSymbol.fromSymbol x) var
-        pure $ IR.PVar var
+        HR.PCon atomName <$> traverse transformPatHR args
+    transformPatHR n
+      | Just x <- Sexp.nameFromT n = do
+        pure $ HR.PVar x
       | Just n@Sexp.N {} <- Sexp.atomFromT n =
-        IR.PPrim <$> getParamConstant n
-      | otherwise = error "malformed match pattern"
-
-    -- TODO ∷ remove this, we do this work in Core
-    getNextPatVar :: HasNextPatVar m => m IR.PatternVar
-    getNextPatVar = state @"nextPatVar" \v -> (v, succ v)
+        HR.PPrim <$> getParamConstant n
+      | otherwise =
+        error "malformed match pattern"


### PR DESCRIPTION
Fixes the bug laid out in #809 where function arguments are being treated as global variables.

#844 is the root cause of this, and this PR serves to fix and create test cases